### PR TITLE
8주차 미션 / 서버 1조 박지원

### DIFF
--- a/src/main/java/kuit/server/controller/CategoryController.java
+++ b/src/main/java/kuit/server/controller/CategoryController.java
@@ -1,0 +1,32 @@
+package kuit.server.controller;
+
+import kuit.server.common.response.BaseResponse;
+import kuit.server.dto.category.response.GetCategoryResponse;
+import kuit.server.dto.store.response.GetStoreResponse;
+import kuit.server.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/categorys")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    /**
+     * 상점 조회
+     */
+    @GetMapping("/{categoryId}")
+    public BaseResponse<GetCategoryResponse> getUserById(
+            @PathVariable long categoryId) {
+        log.info("[StoreController.getUserById]");
+        return new BaseResponse<>(categoryService.findCategoryResponseById(categoryId));
+
+    }
+}

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -44,7 +44,7 @@ public class MemberController {
      */
     @PostMapping("")
     public BaseResponse<PostMemberResponse> signUp(@Validated @RequestBody PostMemberRequest postMemberRequest, BindingResult bindingResult) {
-        log.info("[UserController.signUp]");
+        log.info("[MemberController.signUp]");
         if (bindingResult.hasErrors()) {
             throw new UserException(INVALID_USER_VALUE, getErrorMessages(bindingResult));
         }
@@ -56,7 +56,7 @@ public class MemberController {
      **/
     @PatchMapping("/{memberId}/nickname")
     public BaseResponse<String> changeNickname(@RequestBody Map<String,String> requestMap, @PathVariable Long memberId) {
-        log.info("[UserController.changeNickname]");
+        log.info("[MemberController.changeNickname]");
         return new BaseResponse<>(memberService.changeNickname(memberId,requestMap.get("nickname")));
 
     }
@@ -66,7 +66,7 @@ public class MemberController {
      */
     @PutMapping("/{memberId}")
     public BaseResponse<String> changeAll(@RequestBody PostMemberRequest postMemberRequest, @PathVariable Long memberId) {
-        log.info("[UserController.change]");
+        log.info("[MemberController.change]");
         return new BaseResponse<>(memberService.changeAll(memberId,postMemberRequest));
     }
 
@@ -75,8 +75,16 @@ public class MemberController {
      */
     @GetMapping()
     public BaseResponse<List<GetMemberResponse>> getUsers() {
-        log.info("[UserController.getUserById]");
+        log.info("[MemberController.getUserById]");
         return new BaseResponse<>(memberService.findMemberResponses());
 
+    }
+
+    @DeleteMapping("/{memberId}")
+    public BaseResponse<String> deleteMember(@PathVariable long memberId) {
+        log.info("[MemberController.deleteMember]");
+
+
+        return new BaseResponse<>(memberService.deleteById(memberId));
     }
 }

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -32,11 +32,11 @@ public class MemberController {
     private final MemberService memberService;
     private final PostMemberRequestValidator postMemberRequestValidator;
 
-    @InitBinder
+    /*@InitBinder
     public void init(WebDataBinder webDataBinder){
-        //log.info("init binder {}",webDataBinder);
-        //webDataBinder.addValidators(postMemberRequestValidator);
-    }
+        log.info("init binder {}",webDataBinder);
+        webDataBinder.addValidators(postMemberRequestValidator);
+    }*/
     /**
      * 회원 조회
      */

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -80,11 +80,12 @@ public class MemberController {
 
     }
 
+    /**
+     * 회원 삭제
+     */
     @DeleteMapping("/{memberId}")
     public BaseResponse<String> deleteMember(@PathVariable long memberId) {
         log.info("[MemberController.deleteMember]");
-
-
         return new BaseResponse<>(memberService.deleteById(memberId));
     }
 }

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -5,6 +5,7 @@ import kuit.server.common.response.BaseResponse;
 import kuit.server.dto.member.response.GetMemberResponse;
 import kuit.server.dto.member.request.PostMemberRequest;
 import kuit.server.dto.member.response.PostMemberResponse;
+import kuit.server.dto.user.PatchNicknameRequest;
 import kuit.server.dto.user.PostUserResponse;
 import kuit.server.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 import static kuit.server.common.response.status.BaseExceptionResponseStatus.INVALID_USER_VALUE;
 import static kuit.server.util.BindingResultUtils.getErrorMessages;
@@ -45,5 +48,24 @@ public class MemberController {
             throw new UserException(INVALID_USER_VALUE, getErrorMessages(bindingResult));
         }
         return new BaseResponse<>(memberService.createMemberByPostMemberResponse(postMemberRequest));
+    }
+
+    /**
+     * 회원 닉네임 변경
+     **/
+    @PatchMapping("/{memberId}/nickname")
+    public BaseResponse<String> changeNickname(@RequestBody Map<String,String> requestMap, @PathVariable Long memberId) {
+        log.info("[UserController.changeNickname]");
+        return new BaseResponse<>(memberService.changeNickname(memberId,requestMap.get("nickname")));
+
+    }
+
+    /**
+     * 회원 정보 전부 수정
+     */
+    @PutMapping("/{memberId}")
+    public BaseResponse<String> changeAll(@RequestBody PostMemberRequest postMemberRequest, @PathVariable Long memberId) {
+        log.info("[UserController.change]");
+        return new BaseResponse<>(memberService.changeAll(memberId,postMemberRequest));
     }
 }

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -1,0 +1,31 @@
+package kuit.server.controller;
+
+import kuit.server.common.response.BaseResponse;
+import kuit.server.dto.member.GetMemberResponse;
+import kuit.server.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * 회원 조회
+     */
+    @GetMapping("/{memberId}")
+    public BaseResponse<GetMemberResponse> getUserById(
+            @PathVariable long memberId) {
+        log.info("[UserController.getUserById]");
+        return new BaseResponse<>(memberService.findMemberResponseById(memberId));
+
+    }
+}

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -1,19 +1,25 @@
 package kuit.server.controller;
 
+import kuit.server.common.exception.UserException;
 import kuit.server.common.response.BaseResponse;
-import kuit.server.dto.member.GetMemberResponse;
+import kuit.server.dto.member.response.GetMemberResponse;
+import kuit.server.dto.member.request.PostMemberRequest;
+import kuit.server.dto.member.response.PostMemberResponse;
+import kuit.server.dto.user.PostUserResponse;
 import kuit.server.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static kuit.server.common.response.status.BaseExceptionResponseStatus.INVALID_USER_VALUE;
+import static kuit.server.util.BindingResultUtils.getErrorMessages;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;
@@ -27,5 +33,17 @@ public class MemberController {
         log.info("[UserController.getUserById]");
         return new BaseResponse<>(memberService.findMemberResponseById(memberId));
 
+    }
+
+    /**
+     * 회원 가입
+     */
+    @PostMapping("")
+    public BaseResponse<PostMemberResponse> signUp(@Validated @RequestBody PostMemberRequest postMemberRequest, BindingResult bindingResult) {
+        log.info("[UserController.signUp]");
+        if (bindingResult.hasErrors()) {
+            throw new UserException(INVALID_USER_VALUE, getErrorMessages(bindingResult));
+        }
+        return new BaseResponse<>(memberService.createMemberByPostMemberResponse(postMemberRequest));
     }
 }

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 import static kuit.server.common.response.status.BaseExceptionResponseStatus.INVALID_USER_VALUE;
@@ -67,5 +68,15 @@ public class MemberController {
     public BaseResponse<String> changeAll(@RequestBody PostMemberRequest postMemberRequest, @PathVariable Long memberId) {
         log.info("[UserController.change]");
         return new BaseResponse<>(memberService.changeAll(memberId,postMemberRequest));
+    }
+
+    /**
+     * 회원 전부 수정
+     */
+    @GetMapping()
+    public BaseResponse<List<GetMemberResponse>> getUsers() {
+        log.info("[UserController.getUserById]");
+        return new BaseResponse<>(memberService.findMemberResponses());
+
     }
 }

--- a/src/main/java/kuit/server/controller/MemberController.java
+++ b/src/main/java/kuit/server/controller/MemberController.java
@@ -71,7 +71,7 @@ public class MemberController {
     }
 
     /**
-     * 회원 전부 수정
+     * 회원 전부 조회
      */
     @GetMapping()
     public BaseResponse<List<GetMemberResponse>> getUsers() {

--- a/src/main/java/kuit/server/controller/StoreController.java
+++ b/src/main/java/kuit/server/controller/StoreController.java
@@ -2,16 +2,24 @@ package kuit.server.controller;
 
 import kuit.server.common.exception.UserException;
 import kuit.server.common.response.BaseResponse;
+import kuit.server.dto.member.request.PostMemberRequest;
+import kuit.server.dto.member.response.PostMemberResponse;
+import kuit.server.dto.store.request.PostStoreRequest;
 import kuit.server.dto.store.response.GetStoreResponse;
+import kuit.server.dto.store.response.PostStoreResponse;
 import kuit.server.dto.user.GetUserResponse;
 import kuit.server.service.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 
 
 import static kuit.server.common.response.status.BaseExceptionResponseStatus.INVALID_USER_STATUS;
+import static kuit.server.common.response.status.BaseExceptionResponseStatus.INVALID_USER_VALUE;
+import static kuit.server.util.BindingResultUtils.getErrorMessages;
 
 @Slf4j
 @RestController
@@ -22,7 +30,7 @@ public class StoreController {
     private final StoreService storeService;
 
     /**
-     * 회원 조회
+     * 상점 조회
      */
     @GetMapping("/{storeId}")
     public BaseResponse<GetStoreResponse> getUserById(
@@ -30,5 +38,17 @@ public class StoreController {
         log.info("[StoreController.getUserById]");
         return new BaseResponse<>(storeService.findStoreResponseById(storeId));
 
+    }
+
+    /**
+     * 상점 등록
+     */
+    @PostMapping("")
+    public BaseResponse<PostStoreResponse> addStore(@Validated @RequestBody PostStoreRequest postStoreRequest, BindingResult bindingResult) {
+        log.info("[StoreController.addStore]");
+        if (bindingResult.hasErrors()) {
+            throw new UserException(INVALID_USER_VALUE, getErrorMessages(bindingResult));
+        }
+        return new BaseResponse<>(storeService.createStoreByPostStoreResponse(postStoreRequest));
     }
 }

--- a/src/main/java/kuit/server/controller/StoreController.java
+++ b/src/main/java/kuit/server/controller/StoreController.java
@@ -6,6 +6,7 @@ import kuit.server.dto.member.request.PostMemberRequest;
 import kuit.server.dto.member.response.PostMemberResponse;
 import kuit.server.dto.store.request.PostStoreRequest;
 import kuit.server.dto.store.response.GetStoreResponse;
+import kuit.server.dto.store.response.JoinStoreCategory;
 import kuit.server.dto.store.response.PostStoreResponse;
 import kuit.server.dto.user.GetUserResponse;
 import kuit.server.service.StoreService;
@@ -33,7 +34,7 @@ public class StoreController {
      * 상점 조회
      */
     @GetMapping("/{storeId}")
-    public BaseResponse<GetStoreResponse> getUserById(
+    public BaseResponse<GetStoreResponse> getStoreById(
             @PathVariable long storeId) {
         log.info("[StoreController.getUserById]");
         return new BaseResponse<>(storeService.findStoreResponseById(storeId));
@@ -50,5 +51,17 @@ public class StoreController {
             throw new UserException(INVALID_USER_VALUE, getErrorMessages(bindingResult));
         }
         return new BaseResponse<>(storeService.createStoreByPostStoreResponse(postStoreRequest));
+    }
+
+
+    /**
+     * 상점 + 카테고라 조회
+     */
+    @GetMapping("/{storeId}/categorys")
+    public BaseResponse<JoinStoreCategory> getStoreByIdWithCategory(
+            @PathVariable long storeId) {
+        log.info("[StoreController.getStoreByIdWithCategory]");
+        return new BaseResponse<>(storeService.findStoryWithCategory(storeId));
+
     }
 }

--- a/src/main/java/kuit/server/controller/StoreController.java
+++ b/src/main/java/kuit/server/controller/StoreController.java
@@ -1,0 +1,34 @@
+package kuit.server.controller;
+
+import kuit.server.common.exception.UserException;
+import kuit.server.common.response.BaseResponse;
+import kuit.server.dto.store.response.GetStoreResponse;
+import kuit.server.dto.user.GetUserResponse;
+import kuit.server.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+
+
+import static kuit.server.common.response.status.BaseExceptionResponseStatus.INVALID_USER_STATUS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stores")
+public class StoreController {
+
+    private final StoreService storeService;
+
+    /**
+     * 회원 조회
+     */
+    @GetMapping("/{storeId}")
+    public BaseResponse<GetStoreResponse> getUserById(
+            @PathVariable long storeId) {
+        log.info("[StoreController.getUserById]");
+        return new BaseResponse<>(storeService.findStoreResponseById(storeId));
+
+    }
+}

--- a/src/main/java/kuit/server/controller/UserController.java
+++ b/src/main/java/kuit/server/controller/UserController.java
@@ -2,6 +2,8 @@ package kuit.server.controller;
 
 import kuit.server.common.exception.UserException;
 import kuit.server.common.response.BaseResponse;
+import kuit.server.domain.Member;
+import kuit.server.dto.member.MemberResponse;
 import kuit.server.dto.user.*;
 import kuit.server.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -85,4 +87,14 @@ public class UserController {
         return new BaseResponse<>(userService.getUsers(nickname, email, status));
     }
 
+    /**
+     * 회원 조회
+     */
+    @GetMapping("/{memberId}")
+    public BaseResponse<MemberResponse> getUserById(
+            @PathVariable long memberId) {
+        log.info("[UserController.getUserById]");
+        return new BaseResponse<>(userService.findMemberResponseById(memberId));
+
+    }
 }

--- a/src/main/java/kuit/server/controller/UserController.java
+++ b/src/main/java/kuit/server/controller/UserController.java
@@ -2,8 +2,6 @@ package kuit.server.controller;
 
 import kuit.server.common.exception.UserException;
 import kuit.server.common.response.BaseResponse;
-import kuit.server.domain.Member;
-import kuit.server.dto.member.MemberResponse;
 import kuit.server.dto.user.*;
 import kuit.server.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -87,14 +85,4 @@ public class UserController {
         return new BaseResponse<>(userService.getUsers(nickname, email, status));
     }
 
-    /**
-     * 회원 조회
-     */
-    @GetMapping("/{memberId}")
-    public BaseResponse<MemberResponse> getUserById(
-            @PathVariable long memberId) {
-        log.info("[UserController.getUserById]");
-        return new BaseResponse<>(userService.findMemberResponseById(memberId));
-
-    }
 }

--- a/src/main/java/kuit/server/controller/UserController.java
+++ b/src/main/java/kuit/server/controller/UserController.java
@@ -25,18 +25,6 @@ public class UserController {
     private final UserService userService;
 
     /**
-     * 회원 가입
-     */
-    @PostMapping("")
-    public BaseResponse<PostUserResponse> signUp(@Validated @RequestBody PostUserRequest postUserRequest, BindingResult bindingResult) {
-        log.info("[UserController.signUp]");
-        if (bindingResult.hasErrors()) {
-            throw new UserException(INVALID_USER_VALUE, getErrorMessages(bindingResult));
-        }
-        return new BaseResponse<>(userService.signUp(postUserRequest));
-    }
-
-    /**
      * 회원 휴면
      */
     @PatchMapping("/{userId}/dormant")

--- a/src/main/java/kuit/server/dao/CategoryDao.java
+++ b/src/main/java/kuit/server/dao/CategoryDao.java
@@ -1,0 +1,33 @@
+package kuit.server.dao;
+
+import kuit.server.domain.Category;
+import kuit.server.domain.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+@Slf4j
+@Repository
+public class CategoryDao {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public CategoryDao(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    /**
+     * 유저 조회
+     **/
+    public Category findById(long category_id) {
+        String sql = "select category_id, store_id, name from category where category_id=:category_id";
+        Map<String, Object> param = Map.of("category_id", category_id);
+        return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new Category(
+                Long.parseLong(rs.getString("category_id")),
+                Long.parseLong(rs.getString("store_id")),
+                rs.getString("name")
+        ));
+    }
+}

--- a/src/main/java/kuit/server/dao/MemberDao.java
+++ b/src/main/java/kuit/server/dao/MemberDao.java
@@ -1,9 +1,7 @@
 package kuit.server.dao;
 
 import kuit.server.domain.Member;
-import kuit.server.dto.user.PostUserRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -12,8 +10,6 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Map;
 
 @Slf4j
@@ -49,7 +45,7 @@ public class MemberDao {
     public Long createMember(Member member) {
 
         String sql = "insert into member(member_id, name, nickname, password, phone_num, email) " +
-                "values(:memberId, :name, :nickname, :password, :phone_num, :email)";
+                "values(:memberId, :name, :nickname, :password, :phoneNum, :email)";
 
         SqlParameterSource param = new BeanPropertySqlParameterSource(member);
         KeyHolder keyHolder = new GeneratedKeyHolder();
@@ -84,7 +80,7 @@ public class MemberDao {
                 "name",member.getName(),
                 "nickname", member.getNickname(),
                 "password",member.getPassword(),
-                "phone_num",member.getPhone_num(),
+                "phone_num",member.getPhoneNum(),
                 "email",member.getEmail(),
                 "member_id", member.getMemberId());
         return jdbcTemplate.update(sql, param);

--- a/src/main/java/kuit/server/dao/MemberDao.java
+++ b/src/main/java/kuit/server/dao/MemberDao.java
@@ -102,4 +102,15 @@ public class MemberDao {
                 "member_id", member.getMemberId());
         return jdbcTemplate.update(sql, param);
     }
+
+
+    /**
+     * member 삭제
+     */
+    public int delete(Long member_id) {
+        String sql = "delete from member where member_id=:member_id";
+        Map<String, Object> param = Map.of(
+                "member_id", member_id);
+        return jdbcTemplate.update(sql, param);
+    }
 }

--- a/src/main/java/kuit/server/dao/MemberDao.java
+++ b/src/main/java/kuit/server/dao/MemberDao.java
@@ -1,6 +1,7 @@
 package kuit.server.dao;
 
 import kuit.server.domain.Member;
+import kuit.server.dto.user.GetUserResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -10,6 +11,7 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -29,6 +31,21 @@ public class MemberDao {
         String sql = "select member_id, name, nickname, password, phone_num, email from member where member_id=:member_id";
         Map<String, Object> param = Map.of("member_id", memberId);
         return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new Member(
+                Long.parseLong(rs.getString("member_id")),
+                rs.getString("name"),
+                rs.getString("nickname"),
+                rs.getString("password"),
+                rs.getString("phone_num"),
+                rs.getString("email")
+        ));
+    }
+
+    /**
+     * 유저 전부 조회
+     **/
+    public List<Member> findAll() {
+        String sql = "select member_id, name, nickname, password, phone_num, email from member";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> new Member(
                 Long.parseLong(rs.getString("member_id")),
                 rs.getString("name"),
                 rs.getString("nickname"),

--- a/src/main/java/kuit/server/dao/MemberDao.java
+++ b/src/main/java/kuit/server/dao/MemberDao.java
@@ -26,30 +26,25 @@ public class MemberDao {
         this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
     }
 
-    /*
+    /**
      * 유저 조회
-     */
+     **/
     public Member findById(long memberId) {
         String sql = "select member_id, name, nickname, password, phone_num, email from member where member_id=:member_id";
         Map<String, Object> param = Map.of("member_id", memberId);
-        return jdbcTemplate.queryForObject(sql, param, new RowMapper<Member>() {
-            @Override
-            public Member mapRow(ResultSet rs, int rowNum) throws SQLException {
-                return new Member(
-                        Long.parseLong(rs.getString("member_id")),
-                        rs.getString("name"),
-                        rs.getString("nickname"),
-                        rs.getString("password"),
-                        rs.getString("phone_num"),
-                        rs.getString("email")
-                );
-            }
-        });
+        return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new Member(
+                Long.parseLong(rs.getString("member_id")),
+                rs.getString("name"),
+                rs.getString("nickname"),
+                rs.getString("password"),
+                rs.getString("phone_num"),
+                rs.getString("email")
+        ));
     }
 
-    /*
+    /**
      * 유저 생성
-     */
+     **/
 
     public Long createMember(Member member) {
 
@@ -61,5 +56,37 @@ public class MemberDao {
         jdbcTemplate.update(sql, param, keyHolder);
 
         return 1L;
+    }
+
+    /**
+     * nickname 변경
+     */
+    public int modifyNickname(Long userId, String nickname) {
+        String sql = "update member set nickname=:nickname where member_id=:user_id";
+        Map<String, Object> param = Map.of(
+                "nickname", nickname,
+                "user_id", userId);
+        return jdbcTemplate.update(sql, param);
+    }
+
+    /**
+     * 전부 변경
+     */
+    public int modifyAll(Long userId, Member member) {
+        String sql = "update member set " +
+                "name=:name," +
+                "nickname=:nickname," +
+                "password=:password," +
+                "phone_num=:phone_num," +
+                "email=:email " +
+                "where member_id=:member_id";
+        Map<String, Object> param = Map.of(
+                "name",member.getName(),
+                "nickname", member.getNickname(),
+                "password",member.getPassword(),
+                "phone_num",member.getPhone_num(),
+                "email",member.getEmail(),
+                "member_id", member.getMemberId());
+        return jdbcTemplate.update(sql, param);
     }
 }

--- a/src/main/java/kuit/server/dao/MemberDao.java
+++ b/src/main/java/kuit/server/dao/MemberDao.java
@@ -1,0 +1,65 @@
+package kuit.server.dao;
+
+import kuit.server.domain.Member;
+import kuit.server.dto.user.PostUserRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+@Slf4j
+@Repository
+public class MemberDao {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public MemberDao(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    /*
+     * 유저 조회
+     */
+    public Member findById(long memberId) {
+        String sql = "select member_id, name, nickname, password, phone_num, email from member where member_id=:member_id";
+        Map<String, Object> param = Map.of("member_id", memberId);
+        return jdbcTemplate.queryForObject(sql, param, new RowMapper<Member>() {
+            @Override
+            public Member mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return new Member(
+                        Long.parseLong(rs.getString("member_id")),
+                        rs.getString("name"),
+                        rs.getString("nickname"),
+                        rs.getString("password"),
+                        rs.getString("phone_num"),
+                        rs.getString("email")
+                );
+            }
+        });
+    }
+
+    /*
+     * 유저 생성
+     */
+
+    public Long createMember(Member member) {
+
+        String sql = "insert into member(member_id, name, nickname, password, phone_num, email) " +
+                "values(:memberId, :name, :nickname, :password, :phone_num, :email)";
+
+        SqlParameterSource param = new BeanPropertySqlParameterSource(member);
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(sql, param, keyHolder);
+
+        return 1L;
+    }
+}

--- a/src/main/java/kuit/server/dao/StoreDao.java
+++ b/src/main/java/kuit/server/dao/StoreDao.java
@@ -1,7 +1,7 @@
 package kuit.server.dao;
 
-import kuit.server.domain.Member;
 import kuit.server.domain.Store;
+import kuit.server.dto.store.response.JoinStoreCategory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -51,5 +51,23 @@ public class StoreDao {
         jdbcTemplate.update(sql, param, keyHolder);
 
         return 1L;
+    }
+
+    /**
+     * 상점 + 카테고리 조회
+     **/
+
+    public JoinStoreCategory findByIdWithCategory(long store_id) {
+
+        String sql = "select s.store_id, s.name as store_name, minimum_price, status, c.name as category_name " +
+                "from store s join category c on s.store_id =c.store_id  where s.store_id=:store_id";
+        Map<String, Object> param = Map.of("store_id", store_id);
+        return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new JoinStoreCategory(
+                Long.parseLong(rs.getString("store_id")),
+                rs.getString("store_name"),
+                Long.parseLong(rs.getString("minimum_price")),
+                rs.getString("status"),
+                rs.getString("category_name")
+        ));
     }
 }

--- a/src/main/java/kuit/server/dao/StoreDao.java
+++ b/src/main/java/kuit/server/dao/StoreDao.java
@@ -3,7 +3,11 @@ package kuit.server.dao;
 import kuit.server.domain.Member;
 import kuit.server.domain.Store;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
@@ -20,7 +24,7 @@ public class StoreDao {
     }
 
     /**
-     * 유저 조회
+     * 상점 조회
      **/
     public Store findById(long store_id) {
         String sql = "select store_id, name, minimum_price, status from store where store_id=:store_id";
@@ -28,8 +32,24 @@ public class StoreDao {
         return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new Store(
                 Long.parseLong(rs.getString("store_id")),
                 rs.getString("name"),
-                rs.getString("minimum_price"),
+                Long.parseLong(rs.getString("minimum_price")),
                 rs.getString("status")
         ));
+    }
+
+    /**
+     * 상점 생성
+     **/
+
+    public Long createStore(Store store) {
+
+        String sql = "insert into store(store_id, name, minimum_price, status) " +
+                "values(:storeId, :name, :minimumPrice, :status)";
+
+        SqlParameterSource param = new BeanPropertySqlParameterSource(store);
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(sql, param, keyHolder);
+
+        return 1L;
     }
 }

--- a/src/main/java/kuit/server/dao/StoreDao.java
+++ b/src/main/java/kuit/server/dao/StoreDao.java
@@ -1,0 +1,35 @@
+package kuit.server.dao;
+
+import kuit.server.domain.Member;
+import kuit.server.domain.Store;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+@Slf4j
+@Repository
+public class StoreDao {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public StoreDao(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    /**
+     * 유저 조회
+     **/
+    public Store findById(long store_id) {
+        String sql = "select store_id, name, minimum_price, status, from store where store_id=:store_id";
+        Map<String, Object> param = Map.of("store_id", store_id);
+        return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new Store(
+                Long.parseLong(rs.getString("store_id")),
+                rs.getString("name"),
+                rs.getString("minimum_price"),
+                rs.getString("status")
+        ));
+    }
+}

--- a/src/main/java/kuit/server/dao/StoreDao.java
+++ b/src/main/java/kuit/server/dao/StoreDao.java
@@ -23,7 +23,7 @@ public class StoreDao {
      * 유저 조회
      **/
     public Store findById(long store_id) {
-        String sql = "select store_id, name, minimum_price, status, from store where store_id=:store_id";
+        String sql = "select store_id, name, minimum_price, status from store where store_id=:store_id";
         Map<String, Object> param = Map.of("store_id", store_id);
         return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new Store(
                 Long.parseLong(rs.getString("store_id")),

--- a/src/main/java/kuit/server/dao/StoreDao.java
+++ b/src/main/java/kuit/server/dao/StoreDao.java
@@ -1,6 +1,7 @@
 package kuit.server.dao;
 
 import kuit.server.domain.Store;
+import kuit.server.dto.store.response.GetCategoryResponse;
 import kuit.server.dto.store.response.JoinStoreCategory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
@@ -11,6 +12,9 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -57,17 +61,35 @@ public class StoreDao {
      * 상점 + 카테고리 조회
      **/
 
-    public JoinStoreCategory findByIdWithCategory(long store_id) {
-
+    public JoinStoreCategory findByIdWithCategory(long storeId) {
         String sql = "select s.store_id, s.name as store_name, minimum_price, status, c.name as category_name " +
-                "from store s join category c on s.store_id =c.store_id  where s.store_id=:store_id";
-        Map<String, Object> param = Map.of("store_id", store_id);
-        return jdbcTemplate.queryForObject(sql, param, (rs, rowNum) -> new JoinStoreCategory(
-                Long.parseLong(rs.getString("store_id")),
-                rs.getString("store_name"),
-                Long.parseLong(rs.getString("minimum_price")),
-                rs.getString("status"),
-                rs.getString("category_name")
-        ));
+                "from store s left join category c on s.store_id = c.store_id where s.store_id = :store_id";
+        Map<String, Object> param = Map.of("store_id", storeId);
+
+        List<JoinStoreCategory> results = jdbcTemplate.query(sql, param, (rs) -> {
+            HashMap<Long,JoinStoreCategory>map=new HashMap<>();
+
+            while (rs.next()) {
+                JoinStoreCategory joinStoreCategory = map.get(rs.getLong("store_id"));
+                if (joinStoreCategory == null) {
+                    Long key=rs.getLong("store_id");
+                    joinStoreCategory = new JoinStoreCategory(
+                            key,
+                            rs.getString("store_name"),
+                            rs.getLong("minimum_price"),
+                            new ArrayList<>()
+                    );
+                    map.put(key,joinStoreCategory);
+                }
+                joinStoreCategory.pushCategory(new GetCategoryResponse(
+                        rs.getString("status"),
+                        rs.getString("category_name")
+                ));
+
+            }
+            return new ArrayList<>(map.values());
+        });
+
+        return results.isEmpty() ? null : results.get(0);
     }
 }

--- a/src/main/java/kuit/server/dao/UserDao.java
+++ b/src/main/java/kuit/server/dao/UserDao.java
@@ -1,8 +1,10 @@
 package kuit.server.dao;
 
+import kuit.server.domain.Member;
 import kuit.server.dto.user.GetUserResponse;
 import kuit.server.dto.user.PostUserRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -11,9 +13,12 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 @Slf4j
 @Repository
@@ -101,6 +106,39 @@ public class UserDao {
         String sql = "select password from user where user_id=:user_id and status='active'";
         Map<String, Object> param = Map.of("user_id", userId);
         return jdbcTemplate.queryForObject(sql, param, String.class);
+    }
+
+    /*
+     * 유저 조회
+     */
+    RowMapper<Member> rowMapper = (rs, rowNum) -> new Member(
+            Long.parseLong(rs.getString("member_id")),
+            rs.getString("name"),
+            rs.getString("nickname"),
+            rs.getString("password"),
+            rs.getString("phone_num"),
+            rs.getString("email")
+    );
+    public Member findById(long memberId) {
+        String sql = "select member_id, name, nickname, password, phone_num, email from member where member_id=:member_id";
+        Map<String, Object> param = Map.of("member_id", memberId);
+        try {
+            return jdbcTemplate.queryForObject(sql, param, new RowMapper<Member>() {
+                @Override
+                public Member mapRow(ResultSet rs, int rowNum) throws SQLException {
+                    return new Member(
+                    Long.parseLong(rs.getString("member_id")),
+                            rs.getString("name"),
+                            rs.getString("nickname"),
+                            rs.getString("password"),
+                            rs.getString("phone_num"),
+                            rs.getString("email")
+                    );
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/kuit/server/dao/UserDao.java
+++ b/src/main/java/kuit/server/dao/UserDao.java
@@ -42,17 +42,6 @@ public class UserDao {
         return Boolean.TRUE.equals(jdbcTemplate.queryForObject(sql, param, boolean.class));
     }
 
-    public long createUser(PostUserRequest postUserRequest) {
-        String sql = "insert into user(email, password, phone_number, nickname, profile_image) " +
-                "values(:email, :password, :phoneNumber, :nickname, :profileImage)";
-
-        SqlParameterSource param = new BeanPropertySqlParameterSource(postUserRequest);
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcTemplate.update(sql, param, keyHolder);
-
-        return Objects.requireNonNull(keyHolder.getKey()).longValue();
-    }
-
     public int modifyUserStatus_dormant(long userId) {
         String sql = "update user set status=:status where user_id=:user_id";
         Map<String, Object> param = Map.of(
@@ -111,34 +100,37 @@ public class UserDao {
     /*
      * 유저 조회
      */
-    RowMapper<Member> rowMapper = (rs, rowNum) -> new Member(
-            Long.parseLong(rs.getString("member_id")),
-            rs.getString("name"),
-            rs.getString("nickname"),
-            rs.getString("password"),
-            rs.getString("phone_num"),
-            rs.getString("email")
-    );
     public Member findById(long memberId) {
         String sql = "select member_id, name, nickname, password, phone_num, email from member where member_id=:member_id";
         Map<String, Object> param = Map.of("member_id", memberId);
-        try {
-            return jdbcTemplate.queryForObject(sql, param, new RowMapper<Member>() {
-                @Override
-                public Member mapRow(ResultSet rs, int rowNum) throws SQLException {
-                    return new Member(
-                    Long.parseLong(rs.getString("member_id")),
-                            rs.getString("name"),
-                            rs.getString("nickname"),
-                            rs.getString("password"),
-                            rs.getString("phone_num"),
-                            rs.getString("email")
-                    );
-                }
-            });
-        } catch (Exception e) {
-            return null;
-        }
+        return jdbcTemplate.queryForObject(sql, param, new RowMapper<Member>() {
+            @Override
+            public Member mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return new Member(
+                Long.parseLong(rs.getString("member_id")),
+                        rs.getString("name"),
+                        rs.getString("nickname"),
+                        rs.getString("password"),
+                        rs.getString("phone_num"),
+                        rs.getString("email")
+                );
+            }
+        });
+    }
+
+    /*
+     * 유저 생성
+     */
+
+    public Long createUser(PostUserRequest postUserRequest) {
+        String sql = "insert into user(member_id, name, nickname, password, phone_num, email) " +
+                "values(:member_id, :name, :nickname, :password, :phone_num, :email)";
+
+        SqlParameterSource param = new BeanPropertySqlParameterSource(postUserRequest);
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(sql, param, keyHolder);
+
+        return 1L;
     }
 
 }

--- a/src/main/java/kuit/server/domain/Category.java
+++ b/src/main/java/kuit/server/domain/Category.java
@@ -1,0 +1,14 @@
+package kuit.server.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Category {
+
+    private Long category_id;
+    private Long store_id;
+    private String name;
+}

--- a/src/main/java/kuit/server/domain/Member.java
+++ b/src/main/java/kuit/server/domain/Member.java
@@ -1,0 +1,19 @@
+package kuit.server.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+public class Member {
+
+    private Long memberId;
+    private String name;
+    private String nickname;
+    private String password;
+    private String phone_num;
+    private String email;
+
+}

--- a/src/main/java/kuit/server/domain/Member.java
+++ b/src/main/java/kuit/server/domain/Member.java
@@ -2,8 +2,6 @@ package kuit.server.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @AllArgsConstructor
 @Getter
@@ -13,7 +11,7 @@ public class Member {
     private String name;
     private String nickname;
     private String password;
-    private String phone_num;
+    private String phoneNum;
     private String email;
 
 }

--- a/src/main/java/kuit/server/domain/Store.java
+++ b/src/main/java/kuit/server/domain/Store.java
@@ -1,0 +1,14 @@
+package kuit.server.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Store {
+
+    private Long storeId;
+    private String name;
+    private String minimumPrice;
+    private String status;
+}

--- a/src/main/java/kuit/server/domain/Store.java
+++ b/src/main/java/kuit/server/domain/Store.java
@@ -9,6 +9,6 @@ public class Store {
 
     private Long storeId;
     private String name;
-    private String minimumPrice;
+    private Long minimumPrice;
     private String status;
 }

--- a/src/main/java/kuit/server/dto/category/response/GetCategoryResponse.java
+++ b/src/main/java/kuit/server/dto/category/response/GetCategoryResponse.java
@@ -1,0 +1,20 @@
+package kuit.server.dto.category.response;
+
+import kuit.server.domain.Category;
+import kuit.server.domain.Member;
+import kuit.server.dto.member.response.GetMemberResponse;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetCategoryResponse {
+
+    private Long category_id;
+    private Long store_id;
+    private String name;
+
+    public static GetCategoryResponse of(Category category){
+        return new GetCategoryResponse(category.getCategory_id(),category.getStore_id(),category.getName());
+    }
+}

--- a/src/main/java/kuit/server/dto/member/GetMemberResponse.java
+++ b/src/main/java/kuit/server/dto/member/GetMemberResponse.java
@@ -1,0 +1,21 @@
+package kuit.server.dto.member;
+
+import kuit.server.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+
+@Data
+@AllArgsConstructor
+public class GetMemberResponse {
+    private Long memberId;
+    private String name;
+    private String nickname;
+    private String password;
+    private String phone_num;
+    private String email;
+
+    public static GetMemberResponse of(Member member){
+        return new GetMemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhone_num(),member.getEmail());
+    }
+}

--- a/src/main/java/kuit/server/dto/member/MemberResponse.java
+++ b/src/main/java/kuit/server/dto/member/MemberResponse.java
@@ -1,0 +1,21 @@
+package kuit.server.dto.member;
+
+import kuit.server.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+
+@Data
+@AllArgsConstructor
+public class MemberResponse {
+    private Long memberId;
+    private String name;
+    private String nickname;
+    private String password;
+    private String phone_num;
+    private String email;
+
+    public static MemberResponse of(Member member){
+        return new MemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhone_num(),member.getEmail());
+    }
+}

--- a/src/main/java/kuit/server/dto/member/PostMemberRequest.java
+++ b/src/main/java/kuit/server/dto/member/PostMemberRequest.java
@@ -1,21 +1,16 @@
 package kuit.server.dto.member;
 
-import kuit.server.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-
 @Data
 @AllArgsConstructor
-public class MemberResponse {
+public class PostMemberRequest {
+
     private Long memberId;
     private String name;
     private String nickname;
     private String password;
     private String phone_num;
     private String email;
-
-    public static MemberResponse of(Member member){
-        return new MemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhone_num(),member.getEmail());
-    }
 }

--- a/src/main/java/kuit/server/dto/member/request/PatchMemberNicknameRequest.java
+++ b/src/main/java/kuit/server/dto/member/request/PatchMemberNicknameRequest.java
@@ -1,0 +1,4 @@
+package kuit.server.dto.member.request;
+
+public class PatchMemberNicknameRequest {
+}

--- a/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
+++ b/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
@@ -34,4 +34,5 @@ public class PostMemberRequest {
     public Member toEntity(){
         return new Member(this.memberId,this.name,this.nickname,this.password,this.phoneNum,this.email);
     }
+
 }

--- a/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
+++ b/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
@@ -12,10 +12,10 @@ public class PostMemberRequest {
     private String name;
     private String nickname;
     private String password;
-    private String phone_num;
+    private String phoneNum;
     private String email;
 
     public Member toEntity(){
-        return new Member(this.memberId,this.name,this.nickname,this.password,this.phone_num,this.email);
+        return new Member(this.memberId,this.name,this.nickname,this.password,this.phoneNum,this.email);
     }
 }

--- a/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
+++ b/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
@@ -1,5 +1,6 @@
-package kuit.server.dto.member;
+package kuit.server.dto.member.request;
 
+import kuit.server.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -13,4 +14,8 @@ public class PostMemberRequest {
     private String password;
     private String phone_num;
     private String email;
+
+    public Member toEntity(){
+        return new Member(this.memberId,this.name,this.nickname,this.password,this.phone_num,this.email);
+    }
 }

--- a/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
+++ b/src/main/java/kuit/server/dto/member/request/PostMemberRequest.java
@@ -1,5 +1,9 @@
 package kuit.server.dto.member.request;
 
+import jakarta.annotation.Nonnull;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import kuit.server.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,11 +12,23 @@ import lombok.Data;
 @AllArgsConstructor
 public class PostMemberRequest {
 
+    @Nonnull
     private Long memberId;
+
+    @NotBlank(message = "name: 공백은 허용되지 않습니다")
     private String name;
+
+    @NotBlank(message = "nickname: 공백은 허용되지 않습니다")
     private String nickname;
+
+    @NotBlank(message = "password: 공백은 허용되지 않습니다")
     private String password;
+
+    @NotBlank(message = "phoneNum: 공백은 허용되지 않습니다")
+    @Pattern(regexp = "^010-\\d{3,4}-\\d{4}$", message = "phoneNum: 유효한 휴대폰 번호 형식이어야 합니다. 예: 010-1234-5678")
     private String phoneNum;
+
+    @Email(message = "email: 이메일 형식이어야 합니다")
     private String email;
 
     public Member toEntity(){

--- a/src/main/java/kuit/server/dto/member/response/GetMemberResponse.java
+++ b/src/main/java/kuit/server/dto/member/response/GetMemberResponse.java
@@ -12,11 +12,11 @@ public class GetMemberResponse {
     private String name;
     private String nickname;
     private String password;
-    private String phone_num;
+    private String phoneNum;
     private String email;
 
     public static GetMemberResponse of(Member member){
-        return new GetMemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhone_num(),member.getEmail());
+        return new GetMemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhoneNum(),member.getEmail());
     }
 
 }

--- a/src/main/java/kuit/server/dto/member/response/GetMemberResponse.java
+++ b/src/main/java/kuit/server/dto/member/response/GetMemberResponse.java
@@ -1,4 +1,4 @@
-package kuit.server.dto.member;
+package kuit.server.dto.member.response;
 
 import kuit.server.domain.Member;
 import lombok.AllArgsConstructor;
@@ -18,4 +18,5 @@ public class GetMemberResponse {
     public static GetMemberResponse of(Member member){
         return new GetMemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhone_num(),member.getEmail());
     }
+
 }

--- a/src/main/java/kuit/server/dto/member/response/PostMemberResponse.java
+++ b/src/main/java/kuit/server/dto/member/response/PostMemberResponse.java
@@ -1,0 +1,20 @@
+package kuit.server.dto.member.response;
+
+import kuit.server.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PostMemberResponse {
+    private Long memberId;
+    private String name;
+    private String nickname;
+    private String password;
+    private String phone_num;
+    private String email;
+
+    public static PostMemberResponse of(Member member){
+        return new PostMemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhone_num(),member.getEmail());
+    }
+}

--- a/src/main/java/kuit/server/dto/member/response/PostMemberResponse.java
+++ b/src/main/java/kuit/server/dto/member/response/PostMemberResponse.java
@@ -11,10 +11,10 @@ public class PostMemberResponse {
     private String name;
     private String nickname;
     private String password;
-    private String phone_num;
+    private String phoneNum;
     private String email;
 
     public static PostMemberResponse of(Member member){
-        return new PostMemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhone_num(),member.getEmail());
+        return new PostMemberResponse(member.getMemberId(),member.getName(),member.getNickname(),member.getPassword(),member.getPhoneNum(),member.getEmail());
     }
 }

--- a/src/main/java/kuit/server/dto/store/request/PostStoreRequest.java
+++ b/src/main/java/kuit/server/dto/store/request/PostStoreRequest.java
@@ -1,0 +1,18 @@
+package kuit.server.dto.store.request;
+
+import kuit.server.domain.Store;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PostStoreRequest {
+    private Long storeId;
+    private String name;
+    private Long minimumPrice;
+    private String status;
+
+    public Store toEntity(){
+        return new Store(this.storeId,this.name,this.minimumPrice,this.status);
+    }
+}

--- a/src/main/java/kuit/server/dto/store/response/GetCategoryResponse.java
+++ b/src/main/java/kuit/server/dto/store/response/GetCategoryResponse.java
@@ -1,0 +1,14 @@
+package kuit.server.dto.store.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@ToString
+public class GetCategoryResponse {
+
+    private String status;
+    private String categoryName;
+}

--- a/src/main/java/kuit/server/dto/store/response/GetStoreResponse.java
+++ b/src/main/java/kuit/server/dto/store/response/GetStoreResponse.java
@@ -1,0 +1,19 @@
+package kuit.server.dto.store.response;
+
+import kuit.server.domain.Store;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetStoreResponse {
+
+    private Long storeId;
+    private String name;
+    private String minimumPrice;
+    private String status;
+
+    public static GetStoreResponse of(Store store){
+        return new GetStoreResponse(store.getStoreId(),store.getName(),store.getMinimumPrice(),store.getStatus());
+    }
+}

--- a/src/main/java/kuit/server/dto/store/response/JoinStoreCategory.java
+++ b/src/main/java/kuit/server/dto/store/response/JoinStoreCategory.java
@@ -2,14 +2,23 @@ package kuit.server.dto.store.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
+@ToString
 public class JoinStoreCategory {
 
     private Long storeId;
     private String storeName;
     private Long minimumPrice;
-    private String status;
-    private String categoryName;
+
+    private List<GetCategoryResponse>categoryResponseList=new ArrayList<>();
+
+    public void pushCategory(GetCategoryResponse getCategoryResponse){
+        this.categoryResponseList.add(getCategoryResponse);
+    }
 }

--- a/src/main/java/kuit/server/dto/store/response/JoinStoreCategory.java
+++ b/src/main/java/kuit/server/dto/store/response/JoinStoreCategory.java
@@ -1,0 +1,15 @@
+package kuit.server.dto.store.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JoinStoreCategory {
+
+    private Long storeId;
+    private String storeName;
+    private Long minimumPrice;
+    private String status;
+    private String categoryName;
+}

--- a/src/main/java/kuit/server/dto/store/response/PostStoreResponse.java
+++ b/src/main/java/kuit/server/dto/store/response/PostStoreResponse.java
@@ -6,14 +6,13 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class GetStoreResponse {
-
+public class PostStoreResponse {
     private Long storeId;
     private String name;
     private Long minimumPrice;
     private String status;
 
-    public static GetStoreResponse of(Store store){
-        return new GetStoreResponse(store.getStoreId(),store.getName(),store.getMinimumPrice(),store.getStatus());
+    public static PostStoreResponse of(Store store){
+        return new PostStoreResponse(store.getStoreId(),store.getName(),store.getMinimumPrice(),store.getStatus());
     }
 }

--- a/src/main/java/kuit/server/service/CategoryService.java
+++ b/src/main/java/kuit/server/service/CategoryService.java
@@ -1,0 +1,26 @@
+package kuit.server.service;
+
+import kuit.server.dao.CategoryDao;
+import kuit.server.domain.Category;
+import kuit.server.domain.Store;
+import kuit.server.dto.category.response.GetCategoryResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryDao categoryDao;
+
+    public Category findOneById(Long id){
+        log.info("CategoryService.findOneById");
+        return categoryDao.findById(id);
+    }
+    public GetCategoryResponse findCategoryResponseById(Long id){
+        log.info("CategoryService.findCategoryResponseById");
+        return GetCategoryResponse.of(findOneById(id));
+    }
+}

--- a/src/main/java/kuit/server/service/MemberService.java
+++ b/src/main/java/kuit/server/service/MemberService.java
@@ -15,6 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static kuit.server.common.response.status.BaseExceptionResponseStatus.DUPLICATE_EMAIL;
 
 @Slf4j
@@ -62,9 +65,16 @@ public class MemberService {
             return "success";
         return "fail";
     }
-    /*private void validateEmail(String email) {
-        if (userDao.hasDuplicateEmail(email)) {
-            throw new UserException(DUPLICATE_EMAIL);
-        }
-    }*/
+
+    public List<Member> findAll(){
+        log.info("[UserService.findAll]");
+        return memberDao.findAll();
+    }
+
+    public List<GetMemberResponse>findMemberResponses(){
+        log.info("[UserService.findMemberResponses]");
+        return findAll().stream()
+                .map(GetMemberResponse::of)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/kuit/server/service/MemberService.java
+++ b/src/main/java/kuit/server/service/MemberService.java
@@ -1,25 +1,33 @@
 package kuit.server.service;
 
+import kuit.server.common.exception.UserException;
+import kuit.server.dao.MemberDao;
 import kuit.server.dao.UserDao;
 import kuit.server.domain.Member;
-import kuit.server.dto.member.GetMemberResponse;
+import kuit.server.dto.member.request.PostMemberRequest;
+import kuit.server.dto.member.response.GetMemberResponse;
+import kuit.server.dto.member.response.PostMemberResponse;
+import kuit.server.dto.user.PostUserRequest;
+import kuit.server.dto.user.PostUserResponse;
 import kuit.server.util.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import static kuit.server.common.response.status.BaseExceptionResponseStatus.DUPLICATE_EMAIL;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final UserDao userDao;
+    private final MemberDao memberDao;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     public Member findOneById(Long id){
         log.info("[UserService.findOneById]");
-        return userDao.findById(id);
+        return memberDao.findById(id);
     }
 
     public GetMemberResponse findMemberResponseById(Long id){
@@ -27,5 +35,22 @@ public class MemberService {
         return GetMemberResponse.of(findOneById(id));
     }
 
-    
+    public Member createMember(Member member) {
+        log.info("[UserService.member]");
+        memberDao.createMember(member);
+        return member;
+
+
+    }
+    public PostMemberResponse createMemberByPostMemberResponse(PostMemberRequest postMemberRequest) {
+        log.info("[UserService.createMember]");
+        Member member = createMember(postMemberRequest.toEntity());
+        return PostMemberResponse.of(member);
+    }
+
+    /*private void validateEmail(String email) {
+        if (userDao.hasDuplicateEmail(email)) {
+            throw new UserException(DUPLICATE_EMAIL);
+        }
+    }*/
 }

--- a/src/main/java/kuit/server/service/MemberService.java
+++ b/src/main/java/kuit/server/service/MemberService.java
@@ -39,8 +39,6 @@ public class MemberService {
         log.info("[UserService.member]");
         memberDao.createMember(member);
         return member;
-
-
     }
     public PostMemberResponse createMemberByPostMemberResponse(PostMemberRequest postMemberRequest) {
         log.info("[UserService.createMemberByPostMemberResponse]");

--- a/src/main/java/kuit/server/service/MemberService.java
+++ b/src/main/java/kuit/server/service/MemberService.java
@@ -43,11 +43,27 @@ public class MemberService {
 
     }
     public PostMemberResponse createMemberByPostMemberResponse(PostMemberRequest postMemberRequest) {
-        log.info("[UserService.createMember]");
+        log.info("[UserService.createMemberByPostMemberResponse]");
         Member member = createMember(postMemberRequest.toEntity());
         return PostMemberResponse.of(member);
     }
 
+    public String changeNickname(Long id,String nickname){
+        log.info("[UserService.changeNickname]");
+        if(memberDao.modifyNickname(id,nickname)==1)
+            return "success";
+        return "fail";
+
+    }
+
+    public String changeAll(Long id,PostMemberRequest postMemberRequest){
+        log.info("[UserService.changeAll]");
+        postMemberRequest.setMemberId(id);
+        Member member=postMemberRequest.toEntity();
+        if(memberDao.modifyAll(id,member)==1)
+            return "success";
+        return "fail";
+    }
     /*private void validateEmail(String email) {
         if (userDao.hasDuplicateEmail(email)) {
             throw new UserException(DUPLICATE_EMAIL);

--- a/src/main/java/kuit/server/service/MemberService.java
+++ b/src/main/java/kuit/server/service/MemberService.java
@@ -1,0 +1,31 @@
+package kuit.server.service;
+
+import kuit.server.dao.UserDao;
+import kuit.server.domain.Member;
+import kuit.server.dto.member.GetMemberResponse;
+import kuit.server.util.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final UserDao userDao;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    public Member findOneById(Long id){
+        log.info("[UserService.findOneById]");
+        return userDao.findById(id);
+    }
+
+    public GetMemberResponse findMemberResponseById(Long id){
+        log.info("[UserService.findMemberResponseById]");
+        return GetMemberResponse.of(findOneById(id));
+    }
+
+    
+}

--- a/src/main/java/kuit/server/service/MemberService.java
+++ b/src/main/java/kuit/server/service/MemberService.java
@@ -29,28 +29,28 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     public Member findOneById(Long id){
-        log.info("[UserService.findOneById]");
+        log.info("[MemberService.findOneById]");
         return memberDao.findById(id);
     }
 
     public GetMemberResponse findMemberResponseById(Long id){
-        log.info("[UserService.findMemberResponseById]");
+        log.info("[MemberService.findMemberResponseById]");
         return GetMemberResponse.of(findOneById(id));
     }
 
     public Member createMember(Member member) {
-        log.info("[UserService.member]");
+        log.info("[MemberService.member]");
         memberDao.createMember(member);
         return member;
     }
     public PostMemberResponse createMemberByPostMemberResponse(PostMemberRequest postMemberRequest) {
-        log.info("[UserService.createMemberByPostMemberResponse]");
+        log.info("[MemberService.createMemberByPostMemberResponse]");
         Member member = createMember(postMemberRequest.toEntity());
         return PostMemberResponse.of(member);
     }
 
     public String changeNickname(Long id,String nickname){
-        log.info("[UserService.changeNickname]");
+        log.info("[MemberService.changeNickname]");
         if(memberDao.modifyNickname(id,nickname)==1)
             return "success";
         return "fail";
@@ -58,7 +58,7 @@ public class MemberService {
     }
 
     public String changeAll(Long id,PostMemberRequest postMemberRequest){
-        log.info("[UserService.changeAll]");
+        log.info("[MemberService.changeAll]");
         postMemberRequest.setMemberId(id);
         Member member=postMemberRequest.toEntity();
         if(memberDao.modifyAll(id,member)==1)
@@ -67,14 +67,21 @@ public class MemberService {
     }
 
     public List<Member> findAll(){
-        log.info("[UserService.findAll]");
+        log.info("[MemberService.findAll]");
         return memberDao.findAll();
     }
 
     public List<GetMemberResponse>findMemberResponses(){
-        log.info("[UserService.findMemberResponses]");
+        log.info("[MemberService.findMemberResponses]");
         return findAll().stream()
                 .map(GetMemberResponse::of)
                 .collect(Collectors.toList());
+    }
+
+    public String deleteById(Long id){
+        log.info("[MemberService.deleteById]");
+        if(memberDao.delete(id)==1)
+            return "success";
+        return "fail";
     }
 }

--- a/src/main/java/kuit/server/service/StoreService.java
+++ b/src/main/java/kuit/server/service/StoreService.java
@@ -6,6 +6,7 @@ import kuit.server.domain.Member;
 import kuit.server.domain.Store;
 import kuit.server.dto.store.request.PostStoreRequest;
 import kuit.server.dto.store.response.GetStoreResponse;
+import kuit.server.dto.store.response.JoinStoreCategory;
 import kuit.server.dto.store.response.PostStoreResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,5 +41,8 @@ public class StoreService {
         return PostStoreResponse.of(store);
     }
 
-
+    public JoinStoreCategory findStoryWithCategory(Long id){
+        log.info("[StoreService.findStoryWithCategory]");
+        return storeDao.findByIdWithCategory(id);
+    }
 }

--- a/src/main/java/kuit/server/service/StoreService.java
+++ b/src/main/java/kuit/server/service/StoreService.java
@@ -1,0 +1,26 @@
+package kuit.server.service;
+
+
+import kuit.server.dao.StoreDao;
+import kuit.server.domain.Store;
+import kuit.server.dto.store.response.GetStoreResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    private final StoreDao storeDao;
+
+    public Store findOneById(Long id){
+        log.info("[StoreService.findOneById]");
+        return storeDao.findById(id);
+    }
+
+    public GetStoreResponse findStoreResponseById(Long id){
+        return GetStoreResponse.of(findOneById(id));
+    }
+}

--- a/src/main/java/kuit/server/service/StoreService.java
+++ b/src/main/java/kuit/server/service/StoreService.java
@@ -2,8 +2,11 @@ package kuit.server.service;
 
 
 import kuit.server.dao.StoreDao;
+import kuit.server.domain.Member;
 import kuit.server.domain.Store;
+import kuit.server.dto.store.request.PostStoreRequest;
 import kuit.server.dto.store.response.GetStoreResponse;
+import kuit.server.dto.store.response.PostStoreResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,6 +24,21 @@ public class StoreService {
     }
 
     public GetStoreResponse findStoreResponseById(Long id){
+        log.info("[StoreService.findStoreResponseById]");
         return GetStoreResponse.of(findOneById(id));
     }
+    public Store createStore(Store store) {
+        log.info("[StoreService.createStore]");
+        storeDao.createStore(store);
+        return store;
+    }
+
+    public PostStoreResponse createStoreByPostStoreResponse(PostStoreRequest postStoreRequest){
+        log.info("[StoreService.createStoreByPostStoreResponse]");
+        Store store = postStoreRequest.toEntity();
+        storeDao.createStore(store);
+        return PostStoreResponse.of(store);
+    }
+
+
 }

--- a/src/main/java/kuit/server/service/UserService.java
+++ b/src/main/java/kuit/server/service/UserService.java
@@ -3,6 +3,8 @@ package kuit.server.service;
 import kuit.server.common.exception.DatabaseException;
 import kuit.server.common.exception.UserException;
 import kuit.server.dao.UserDao;
+import kuit.server.domain.Member;
+import kuit.server.dto.member.MemberResponse;
 import kuit.server.dto.user.*;
 import kuit.server.util.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -92,4 +94,13 @@ public class UserService {
         }
     }
 
+    public Member findOneById(Long id){
+        log.info("[UserService.findOneById]");
+        return userDao.findById(id);
+    }
+
+    public MemberResponse findMemberResponseById(Long id){
+        log.info("[UserService.findMemberResponseById]");
+        return MemberResponse.of(findOneById(id));
+    }
 }

--- a/src/main/java/kuit/server/service/UserService.java
+++ b/src/main/java/kuit/server/service/UserService.java
@@ -3,8 +3,6 @@ package kuit.server.service;
 import kuit.server.common.exception.DatabaseException;
 import kuit.server.common.exception.UserException;
 import kuit.server.dao.UserDao;
-import kuit.server.domain.Member;
-import kuit.server.dto.member.MemberResponse;
 import kuit.server.dto.user.*;
 import kuit.server.util.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -94,13 +92,4 @@ public class UserService {
         }
     }
 
-    public Member findOneById(Long id){
-        log.info("[UserService.findOneById]");
-        return userDao.findById(id);
-    }
-
-    public MemberResponse findMemberResponseById(Long id){
-        log.info("[UserService.findMemberResponseById]");
-        return MemberResponse.of(findOneById(id));
-    }
 }

--- a/src/main/java/kuit/server/util/BindingResultUtils.java
+++ b/src/main/java/kuit/server/util/BindingResultUtils.java
@@ -1,0 +1,14 @@
+package kuit.server.util;
+
+import org.springframework.validation.BindingResult;
+
+public class BindingResultUtils {
+
+    public static String getErrorMessages(BindingResult bindingResult) {
+        StringBuilder errorMessages = new StringBuilder();
+        bindingResult.getAllErrors()
+                .forEach(error -> errorMessages.append(error.getDefaultMessage()).append(". "));
+        return errorMessages.toString();
+    }
+
+}


### PR DESCRIPTION
<!--  pr 작성이 어려우시다면 해당 템플릿을 이용해주세요! 본인만의 스타일이 있으시다면 요거 다 지우고 스타일 고수해주시면 돼용ㅎㅎ😊👍  -->
안녕하세요  서버 1조 [박지원(david-parkk)](https://github.com/david-parkk)입니다. 😄 
이번주에는 지난주에 구현한 API구현을 리펙토링하는 시간을 가졌습니다. 또한 Validator을 직접 적용하는 시간을 가졌습니다.
미션을 진행하면서 생각해본 내용에 대해 아래 적었습니다
## 미션 진행도
<!--  필수  -->
- [x] API 리펙토링
- [x]  Validator 검증

### API
- 회원조회
- 회원생성
- 닉네임 수정
- 회원 변경
- 회원 삭제
- 회원전부조회
- 상점조회
- 상점등록
- 카테고리조회
- 상점+카테고리 조회
   
### 1.  조인 쿼리 👫 
- 조인 쿼리에 대한 엔티티 mapping 처리가 상당히 번잡하게 처리되었습니다. `NamedParameterJdbcTemplate `에서 지원하는 query에 추가적으로 몇가지 처리를 해줘야했습니다.(`List`의 첫번째 element를 반환)
- `ResultSet `내부에서도 `HashMap`을 선언해서 구현해하는 등 처리 할게 생각보다 많았습니다


### 2.  exceptionhandler 🌀 
- 따로 `exceptionhandler`를 명시하지 않아도 스프링부트를 실행해보면 `response`가 생각보다 잘 처리되는 것을 확인할 수 있습니다.
- 이러한 처리가 was에서 어느정도 구현되어 있다고 이해했습니다
- 또한 `exceptionhandler` 를 사용하면 예외를 발생시키는 것 만으로도 `response`를 명세할 수 있게 되는데요
- 이는 `exceptionhandler` 에 예외에 대한 확인 후 만약 예외가 발생했다면 `exceptionhandler`가 `response`에 대한 통제권을 가져와 `response`를 구성한다고 이해했습니다.(자바에서 예외가 발생하는 것과 비슷한 원리)

![image](https://github.com/Konkuk-KUIT/KUIT3_Server/assets/57484954/fa34ec64-9eac-4112-afe7-b6259b176835)

